### PR TITLE
feat: initial thread tracking functionality

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -13,6 +13,12 @@
 | setstaffrole | Role      | Set the bot staff role.            |
 | setup        |           | Configure a guild to use this bot. |
 
+## Thread
+| Commands | Arguments | Description                     |
+| -------- | --------- | ------------------------------- |
+| stats    |           | View thread stats for a channel |
+|          | Channel   |                                 |
+
 ## Utility
 | Commands | Arguments | Description               |
 | -------- | --------- | ------------------------- |

--- a/src/main/kotlin/me/ddivad/threadsafe/Main.kt
+++ b/src/main/kotlin/me/ddivad/threadsafe/Main.kt
@@ -1,6 +1,8 @@
 package me.ddivad.threadsafe
 
 import dev.kord.common.annotation.KordPreview
+import dev.kord.gateway.Intent
+import dev.kord.gateway.Intents
 import dev.kord.gateway.PrivilegedIntent
 import me.ddivad.threadsafe.dataclasses.Configuration
 import me.ddivad.threadsafe.dataclasses.Permissions
@@ -29,7 +31,10 @@ suspend fun main() {
             allowMentionPrefix = true
             commandReaction = null
             theme = Color.MAGENTA
-            permissions(Permissions.NONE)
+            permissions(Permissions.STAFF)
+            intents = Intents(
+                Intent.Guilds
+            )
         }
 
         mentionEmbed {
@@ -56,9 +61,9 @@ suspend fun main() {
             field {
                 name = "Build Info"
                 value = "```" +
-                        "Version:   1.0.0\n" +
+                        "Version: 1.0.0\n" +
                         "DiscordKt: ${versions.library}\n" +
-                        "Kotlin:    $kotlinVersion" +
+                        "Kotlin: $kotlinVersion" +
                         "```"
             }
 

--- a/src/main/kotlin/me/ddivad/threadsafe/commands/ThreadCommands.kt
+++ b/src/main/kotlin/me/ddivad/threadsafe/commands/ThreadCommands.kt
@@ -1,0 +1,25 @@
+package me.ddivad.threadsafe.commands
+
+import me.ddivad.threadsafe.dataclasses.Configuration
+import me.ddivad.threadsafe.embeds.createThreadStatsEmbed
+import me.ddivad.threadsafe.embeds.createThreadStatsEmbedForChannel
+import me.jakejmattson.discordkt.arguments.ChannelArg
+import me.jakejmattson.discordkt.commands.commands
+
+@Suppress("unused")
+fun threadCommands(configuration: Configuration) = commands("Thread") {
+    command("stats") {
+        description = "View thread stats for a channel"
+        execute {
+            val guildConfiguration = configuration[guild.id] ?: return@execute
+            respond { createThreadStatsEmbed(guild, guildConfiguration.stats) }
+        }
+
+        execute(ChannelArg) {
+            val channel = args.first
+            val guildConfiguration = configuration[guild.id] ?: return@execute
+            val threadsForChannel = guildConfiguration.stats.filter { it.channelId == channel.id }
+            respond { createThreadStatsEmbedForChannel(guild, guildConfiguration.stats, channel) }
+        }
+    }
+}

--- a/src/main/kotlin/me/ddivad/threadsafe/dataclasses/Configuration.kt
+++ b/src/main/kotlin/me/ddivad/threadsafe/dataclasses/Configuration.kt
@@ -37,5 +37,9 @@ data class GuildConfiguration(
     var prefix: String = "++",
     var staffRoleId: Snowflake,
     var adminRoleId: Snowflake,
-    var notificationChannel: Snowflake
+    var notificationChannel: Snowflake,
+    val stats: MutableList<ThreadStats> = mutableListOf()
 )
+
+@Serializable
+data class ThreadStats(val channelId: Snowflake, val parentChannelId: Snowflake, val dateTime: Long)

--- a/src/main/kotlin/me/ddivad/threadsafe/embeds/ThreadStatEmbeds.kt
+++ b/src/main/kotlin/me/ddivad/threadsafe/embeds/ThreadStatEmbeds.kt
@@ -1,0 +1,53 @@
+package me.ddivad.threadsafe.embeds
+
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.kColor
+import dev.kord.core.entity.Guild
+import dev.kord.core.entity.channel.TextChannel
+import dev.kord.rest.Image
+import dev.kord.rest.builder.message.EmbedBuilder
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.flow.toList
+import me.ddivad.threadsafe.dataclasses.ThreadStats
+import me.jakejmattson.discordkt.extensions.toTimeString
+import java.awt.Color
+
+suspend fun EmbedBuilder.createThreadStatsEmbed(guild: Guild, threadStats: MutableList<ThreadStats>) {
+    title = "Thread Statistics"
+    color = Color.MAGENTA.kColor
+
+    val filtered = threadStats.fold(HashMap<Snowflake, Int>()) { acc, next ->
+        acc[next.channelId] = acc.getOrDefault(next.channelId, 0) + 1
+        return@fold acc
+    }.entries.map { "${guild.getChannel(it.key).mention} - ${it.value}" }
+
+    description = """
+        Showing total threads created:
+        
+        ${filtered.joinToString("\n")}
+    """.trimIndent()
+
+    footer {
+        icon = guild.getIconUrl(Image.Format.PNG) ?: ""
+        text = guild.name
+    }
+}
+
+suspend fun EmbedBuilder.createThreadStatsEmbedForChannel(guild: Guild, threadStats: MutableList<ThreadStats>, channel: TextChannel) {
+    val channelThreads = threadStats.filter { it.parentChannelId == channel.id }.sortedBy { it.dateTime }
+    val mostRecentThread = channelThreads.lastOrNull()
+
+    title = "Thread Statistics for **#${channel.name}**"
+    color = Color.MAGENTA.kColor
+    description = """
+        Total threads created: **${channelThreads.size}**
+        Current active threads: **${channel.activeThreads.count()}**
+        ${if(mostRecentThread != null) "Last thread created: ${guild.getChannel(mostRecentThread.channelId).mention} (<t:${mostRecentThread.dateTime}:R>)" else ""}
+    """.trimIndent()
+
+    footer {
+        icon = guild.getIconUrl(Image.Format.PNG) ?: ""
+        text = guild.name
+    }
+}


### PR DESCRIPTION
# feat: initial thread tracking functionality

Add initial functionality to track thread creation.

- Add thread listener to save thread stats and log creation.
- Add stats command to view thread stats as a whole, or per channel.